### PR TITLE
Build dashboard bundle and require it in simple server

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,32 @@
 {
-  "name": "gate-io-tradingview-bot",
-  "version": "3.0.0",
+  "name": "gate.io-futures-trading-ui",
+  "version": "1.0.0",
+  "private": true,
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "start:simple": "node server-simple.js",
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --host"
   },
   "dependencies": {
-    "express": "^4.18.2",
     "axios": "^1.6.0",
-    "dotenv": "^16.3.1",
     "body-parser": "^1.20.2",
-    "cors": "^2.8.5"
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "autoprefixer": "^10.4.19",
+    "postcss": "^8.4.39",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "tailwindcss": "^3.4.4",
+    "typescript": "^5.2.2",
+    "vite": "^5.3.3"
   }
 }

--- a/server-simple.js
+++ b/server-simple.js
@@ -1,3 +1,5 @@
+const fs = require('fs');
+const path = require('path');
 const express = require('express');
 const app = express();
 
@@ -7,19 +9,128 @@ const PORT = process.env.PORT || 8080;
 // 미들웨어
 app.use(express.json());
 
+const distDir = path.join(__dirname, 'dist');
+const publicDir = path.join(__dirname, 'public');
+const distIndexPath = path.join(distDir, 'index.html');
+const publicIndexPath = path.join(publicDir, 'index.html');
+const serviceWorkerPath = path.join(__dirname, 'service-worker.js');
+
+// 정적 파일 경로 구성 (index.html은 직접 서빙)
+[
+    distDir,
+    publicDir
+]
+    .filter((dir) => fs.existsSync(dir))
+    .forEach((dir) => {
+        app.use(express.static(dir, { index: false }));
+    });
+
+if (fs.existsSync(serviceWorkerPath)) {
+    app.get('/service-worker.js', (req, res) => {
+        res.type('application/javascript').sendFile(serviceWorkerPath);
+    });
+}
+
+const fileExists = (filePath) => {
+    try {
+        const stats = fs.statSync(filePath);
+        return stats.isFile();
+    } catch (err) {
+        if (err.code !== 'ENOENT') {
+            console.error(`Failed to stat ${filePath}`, err);
+        }
+        return false;
+    }
+};
+
+let loggedMissingBundle = false;
+let lastResolvedDashboard = null;
+
+const resolveDashboardFile = () => {
+    if (fileExists(distIndexPath)) {
+        if (lastResolvedDashboard !== distIndexPath) {
+            console.log(`Serving dashboard from ${distIndexPath}`);
+            lastResolvedDashboard = distIndexPath;
+        }
+        return distIndexPath;
+    }
+
+    if (!loggedMissingBundle) {
+        loggedMissingBundle = true;
+        console.error(
+            'Dashboard bundle not found at dist/index.html. Run `npm run build` before deploying the simple server.',
+        );
+    }
+
+    if (process.env.ALLOW_PUBLIC_PLACEHOLDER === 'true' && fileExists(publicIndexPath)) {
+        if (lastResolvedDashboard !== publicIndexPath) {
+            console.warn('Falling back to public/index.html placeholder because built assets are missing.');
+            lastResolvedDashboard = publicIndexPath;
+        }
+        return publicIndexPath;
+    }
+
+    return null;
+};
+
+const shouldReturnJson = (req) => {
+    if (req.query.format === 'json') {
+        return true;
+    }
+
+    const acceptHeader = req.headers.accept || '';
+    if (!acceptHeader) {
+        // 기본적으로 브라우저는 text/html을 요청하므로, 명시적인 Accept가 없으면 HTML 반환
+        return false;
+    }
+
+    const accepts = req.accepts(['html', 'json']);
+    if (accepts === 'json') {
+        return true;
+    }
+
+    if (acceptHeader.includes('application/json') && !acceptHeader.includes('text/html')) {
+        return true;
+    }
+
+    return false;
+};
+
+const respondWithStatusJson = (res) => {
+    res.json({
+        message: 'Gate.io Trading Bot is running',
+        port: PORT,
+        timestamp: new Date().toISOString()
+    });
+};
+
+const serveDashboard = (req, res) => {
+    if (shouldReturnJson(req)) {
+        return respondWithStatusJson(res);
+    }
+
+    const dashboardFile = resolveDashboardFile();
+
+    if (!dashboardFile) {
+        return res
+            .status(500)
+            .type('text/plain; charset=utf-8')
+            .send('Dashboard bundle is missing. Please run `npm run build` before starting the server.');
+    }
+
+    return res.sendFile(dashboardFile);
+};
+
 // Health check endpoint - Cloud Run이 확인하는 엔드포인트
 app.get('/health', (req, res) => {
     res.status(200).json({ status: 'healthy', timestamp: new Date().toISOString() });
 });
 
-// Root endpoint
-app.get('/', (req, res) => {
-    res.json({ 
-        message: 'Gate.io Trading Bot is running',
-        port: PORT,
-        timestamp: new Date().toISOString()
-    });
-});
+// Root endpoint (대시보드 또는 JSON 상태 정보 제공)
+app.get('/', serveDashboard);
+
+// 관리자/프론트엔드 라우트는 모두 동일한 대시보드를 서빙
+app.get(['/admin', '/admin/*'], serveDashboard);
 
 // Webhook endpoint
 app.post('/webhook', (req, res) => {


### PR DESCRIPTION
## Summary
- add Vite build scripts and dev dependencies to package.json so the dashboard bundle can be produced
- update the Dockerfile to run a multi-stage build that compiles the React UI and installs only production dependencies in the runtime image
- tighten server-simple routing to require the built dashboard bundle, expose the service worker, and allow an opt-in placeholder fallback via environment variable

## Testing
- ⚠️ `npm install --package-lock-only` *(fails: registry responded with HTTP 403 while downloading @types/react)*

------
https://chatgpt.com/codex/tasks/task_b_68d33f79d4b8832ca9f6d1c1638e45a2