### PR TITLE
Add mock API endpoints for integrated dashboard

### DIFF
--- a/server-simple.js
+++ b/server-simple.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
 const express = require('express');
 const app = express();
 
@@ -42,6 +43,657 @@ const buildEmptyAccounts = () => ({
     margin: [],
     options: null,
     totalEstimatedValue: 0
+});
+
+const nowIsoString = () => new Date().toISOString();
+
+const defaultStrategies = [
+    {
+        id: 'btc-scalping-v1',
+        name: 'BTC USDT 스캘핑 전략',
+        description: '고빈도 스캘핑 전략으로 BTC_USDT 선물 포지션을 관리합니다.',
+        active: true,
+        createdAt: nowIsoString(),
+        updatedAt: nowIsoString()
+    },
+    {
+        id: 'eth-swing-v1',
+        name: 'ETH 스윙 전략',
+        description: 'ETHUSDT 스윙 트레이딩 전략으로 2시간 주기를 사용합니다.',
+        active: true,
+        createdAt: nowIsoString(),
+        updatedAt: nowIsoString()
+    },
+    {
+        id: 'macro-arbitrage',
+        name: '거시 아비트라지',
+        description: '시장 변동성 지표 기반으로 포지션을 분산합니다.',
+        active: true,
+        createdAt: nowIsoString(),
+        updatedAt: nowIsoString()
+    }
+];
+
+const defaultSignals = [
+    {
+        id: 'sig-001',
+        timestamp: nowIsoString(),
+        action: 'open',
+        side: 'buy',
+        symbol: 'BTC_USDT',
+        size: 100,
+        leverage: 10,
+        status: 'delivered',
+        strategyId: 'btc-scalping-v1',
+        indicator: 'BTC Scalping - 15m',
+        autoTradingExecuted: true
+    },
+    {
+        id: 'sig-002',
+        timestamp: nowIsoString(),
+        action: 'close',
+        side: 'sell',
+        symbol: 'ETH_USDT',
+        size: 50,
+        leverage: 8,
+        status: 'delivered',
+        strategyId: 'eth-swing-v1',
+        indicator: 'ETH Swing - 2h',
+        autoTradingExecuted: false
+    }
+];
+
+const defaultPositions = [
+    {
+        contract: 'BTC_USDT',
+        size: 0.42,
+        side: 'long',
+        leverage: 10,
+        margin: 520,
+        pnl: 138,
+        pnlPercentage: 5.6,
+        entryPrice: 61000,
+        markPrice: 64280,
+        value: 27000
+    },
+    {
+        contract: 'ETH_USDT',
+        size: 1.8,
+        side: 'short',
+        leverage: 6,
+        margin: 430,
+        pnl: -24,
+        pnlPercentage: -1.8,
+        entryPrice: 3400,
+        markPrice: 3475,
+        value: 6260
+    }
+];
+
+const generateLogEntry = (message, level = 'info') => ({
+    id: `log-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`,
+    timestamp: nowIsoString(),
+    message,
+    level
+});
+
+const buildInitialLogs = () => [
+    generateLogEntry('[SYSTEM] Gate.io Trading Bot 대시보드가 시작되었습니다.'),
+    generateLogEntry('[WEBHOOK] 테스트 모드가 활성화되어 있습니다.'),
+    generateLogEntry('[API] 기본 데모 데이터가 로드되었습니다.')
+];
+
+const dataStore = {
+    logs: buildInitialLogs(),
+    strategies: new Map(),
+    users: new Map(),
+    signals: defaultSignals.slice(),
+    webhook: {
+        url: null,
+        secret: null,
+        createdAt: null,
+        updatedAt: null,
+        routes: []
+    },
+    webhookDeliveries: [
+        {
+            id: 'delivery-001',
+            timestamp: nowIsoString(),
+            indicator: 'BTC Scalping - 15m',
+            symbol: 'BTC_USDT',
+            action: 'open',
+            side: 'buy',
+            strategyId: 'btc-scalping-v1',
+            strategyName: 'BTC USDT 스캘핑 전략',
+            delivered: 1,
+            recipients: [
+                {
+                    uid: '123456',
+                    status: 'approved',
+                    autoTradingEnabled: true,
+                    approved: true
+                }
+            ]
+        }
+    ],
+    metrics: {
+        totalVisits: 0,
+        lastVisitAt: null,
+        sessions: new Map(),
+        lastSignal: defaultSignals[0] || null,
+        signalRecipients: {
+            active: 1,
+            lastSignalAt: defaultSignals[0]?.timestamp || null,
+            lastDeliveredCount: 1
+        }
+    }
+};
+
+defaultStrategies.forEach((strategy) => {
+    dataStore.strategies.set(strategy.id, { ...strategy });
+});
+
+const seedUsers = () => {
+    const approvedUser = {
+        uid: '123456',
+        status: 'approved',
+        requestedStrategies: defaultStrategies.map((strategy) => strategy.id),
+        approvedStrategies: defaultStrategies.map((strategy) => strategy.id),
+        accessKey: 'access_7390e86e7e8c',
+        autoTradingEnabled: true,
+        createdAt: nowIsoString(),
+        updatedAt: nowIsoString(),
+        approvedAt: nowIsoString(),
+        signals: defaultSignals.slice(),
+        positions: defaultPositions.slice()
+    };
+
+    const pendingUser = {
+        uid: '777777',
+        status: 'pending',
+        requestedStrategies: ['eth-swing-v1'],
+        approvedStrategies: [],
+        accessKey: null,
+        autoTradingEnabled: false,
+        createdAt: nowIsoString(),
+        updatedAt: nowIsoString(),
+        approvedAt: null,
+        signals: [],
+        positions: []
+    };
+
+    dataStore.users.set(approvedUser.uid, approvedUser);
+    dataStore.users.set(pendingUser.uid, pendingUser);
+};
+
+seedUsers();
+
+const ADMIN_TOKEN = normaliseString(
+    process.env.ADMIN_TOKEN || process.env.ADMIN_SECRET || process.env.ADMIN_KEY,
+    'demo-admin-token'
+);
+
+const appendLog = (message, level = 'info') => {
+    dataStore.logs.push(generateLogEntry(message, level));
+    if (dataStore.logs.length > 500) {
+        dataStore.logs.splice(0, dataStore.logs.length - 500);
+    }
+};
+
+const generateAccessKey = () => {
+    if (crypto.randomUUID) {
+        return `access_${crypto.randomUUID().replace(/-/g, '').slice(0, 12)}`;
+    }
+    return `access_${Math.random().toString(16).slice(2, 14)}`;
+};
+
+const mapStrategyIdsToNamedList = (ids = []) => {
+    return ids
+        .filter((id) => typeof id === 'string' && id)
+        .map((id) => {
+            const strategy = dataStore.strategies.get(id);
+            return {
+                id,
+                name: strategy?.name || id
+            };
+        });
+};
+
+const countActiveVisitors = () => {
+    const now = Date.now();
+    const THRESHOLD = 1000 * 60 * 5; // 5 minutes
+    let active = 0;
+    dataStore.metrics.sessions.forEach((session) => {
+        if (now - session.lastSeen <= THRESHOLD) {
+            active += 1;
+        }
+    });
+    return active;
+};
+
+const buildUserStatusPayload = (user) => ({
+    status: user.status,
+    requestedStrategies: mapStrategyIdsToNamedList(user.requestedStrategies),
+    approvedStrategies: mapStrategyIdsToNamedList(user.approvedStrategies),
+    accessKey: user.accessKey,
+    autoTradingEnabled: Boolean(user.autoTradingEnabled)
+});
+
+const ensureUserExists = (uid) => {
+    if (!uid) {
+        return null;
+    }
+    if (!dataStore.users.has(uid)) {
+        const newUser = {
+            uid,
+            status: 'not_registered',
+            requestedStrategies: [],
+            approvedStrategies: [],
+            accessKey: null,
+            autoTradingEnabled: false,
+            createdAt: nowIsoString(),
+            updatedAt: nowIsoString(),
+            approvedAt: null,
+            signals: [],
+            positions: []
+        };
+        dataStore.users.set(uid, newUser);
+    }
+    return dataStore.users.get(uid);
+};
+
+const refreshMetricsSnapshot = () => {
+    dataStore.metrics.visitors = {
+        active: countActiveVisitors(),
+        totalSessions: dataStore.metrics.sessions.size,
+        lastVisitAt: dataStore.metrics.lastVisitAt
+    };
+
+    const approvedUsers = Array.from(dataStore.users.values()).filter((user) => user.status === 'approved');
+    dataStore.metrics.signalRecipients.active = approvedUsers.length;
+};
+
+const resolveUserForCredentialCheck = (uid, key) => {
+    const normalisedUid = normaliseString(uid);
+    const normalisedKey = normaliseString(key);
+
+    if (!normalisedUid || !normalisedKey) {
+        return { error: 'missing_credentials', status: 403 };
+    }
+
+    const user = dataStore.users.get(normalisedUid);
+    if (!user) {
+        return { error: 'uid_not_found', status: 403 };
+    }
+
+    if (user.accessKey !== normalisedKey) {
+        return { error: 'uid_credentials_mismatch', status: 403 };
+    }
+
+    if (user.status !== 'approved') {
+        return { error: 'uid_not_approved', status: 403 };
+    }
+
+    return { user };
+};
+
+const serialiseLogs = () => dataStore.logs.slice().reverse();
+
+const serialiseStrategies = () =>
+    Array.from(dataStore.strategies.values()).map((strategy) => ({
+        id: strategy.id,
+        name: strategy.name,
+        description: strategy.description,
+        active: strategy.active !== false,
+        createdAt: strategy.createdAt,
+        updatedAt: strategy.updatedAt
+    }));
+
+const serialiseUsersForAdmin = () =>
+    Array.from(dataStore.users.values()).map((user) => ({
+        uid: user.uid,
+        status: user.status,
+        requestedStrategies: user.requestedStrategies.slice(),
+        approvedStrategies: user.approvedStrategies.slice(),
+        accessKey: user.status === 'approved' ? user.accessKey : null,
+        createdAt: user.createdAt,
+        updatedAt: user.updatedAt,
+        approvedAt: user.approvedAt
+    }));
+
+const handleUserStatus = (req, res) => {
+    const uid = normaliseString(req.query.uid);
+    if (!uid) {
+        return res.status(400).json({
+            ok: false,
+            code: 'missing_uid',
+            message: 'UID가 필요합니다.'
+        });
+    }
+
+    const user = ensureUserExists(uid);
+    return res.json(buildUserStatusPayload(user));
+};
+
+const handleRegister = (req, res) => {
+    const uid = normaliseString(req.body && req.body.uid);
+    if (!uid) {
+        return res.status(400).json({
+            ok: false,
+            code: 'missing_uid',
+            message: 'UID를 입력해주세요.'
+        });
+    }
+
+    const user = ensureUserExists(uid);
+
+    if (user.status === 'approved') {
+        return res.json({
+            ok: true,
+            status: user.status,
+            message: '이미 승인된 사용자입니다.',
+            accessKey: user.accessKey
+        });
+    }
+
+    user.status = 'pending';
+    user.updatedAt = nowIsoString();
+    if (!user.requestedStrategies.length) {
+        user.requestedStrategies = serialiseStrategies()
+            .filter((strategy) => strategy.active)
+            .map((strategy) => strategy.id);
+    }
+
+    appendLog(`[USER] UID ${uid}가 등록을 요청했습니다.`);
+
+    return res.json({
+        ok: true,
+        status: user.status,
+        message: '등록 요청이 접수되었습니다.'
+    });
+};
+
+const handleUserSignals = (req, res) => {
+    const { user, error, status } = resolveUserForCredentialCheck(req.query.uid, req.query.key);
+    if (error) {
+        return res.status(status).json({
+            ok: false,
+            code: error,
+            message: '신호를 가져오지 못했습니다.'
+        });
+    }
+
+    const signals = Array.isArray(user.signals) ? user.signals.slice() : [];
+    if (signals.length) {
+        dataStore.metrics.lastSignal = signals[signals.length - 1];
+        dataStore.metrics.signalRecipients.lastSignalAt = dataStore.metrics.lastSignal.timestamp;
+        dataStore.metrics.signalRecipients.lastDeliveredCount = signals.length;
+    }
+
+    return res.json({
+        ok: true,
+        signals
+    });
+};
+
+const handlePositions = (req, res) => {
+    const { user, error, status } = resolveUserForCredentialCheck(req.query.uid, req.query.key);
+    if (error) {
+        if (error === 'missing_credentials') {
+            return res.status(status).json({
+                code: error,
+                message: 'UID와 액세스 키가 필요합니다.',
+                positions: []
+            });
+        }
+        return res.status(status).json({
+            code: error,
+            message: '포지션을 가져오지 못했습니다.',
+            positions: []
+        });
+    }
+
+    const positions = Array.isArray(user.positions) ? user.positions.slice() : [];
+    return res.json({
+        ok: true,
+        positions
+    });
+};
+
+const adminAuthMiddleware = (req, res, next) => {
+    const token = normaliseString(req.headers['x-admin-token']);
+    if (!token || token !== ADMIN_TOKEN) {
+        return res.status(401).json({
+            ok: false,
+            message: '관리자 인증에 실패했습니다.'
+        });
+    }
+    return next();
+};
+
+const adminRouter = express.Router();
+adminRouter.use(adminAuthMiddleware);
+
+adminRouter.get('/overview', (req, res) => {
+    const users = serialiseUsersForAdmin();
+    const strategies = serialiseStrategies();
+    const stats = {
+        totalUsers: users.length,
+        pending: users.filter((user) => user.status === 'pending').length,
+        approved: users.filter((user) => user.status === 'approved').length
+    };
+
+    res.json({
+        users,
+        strategies,
+        stats
+    });
+});
+
+adminRouter.get('/signals', (req, res) => {
+    const strategyId = normaliseString(req.query.strategy);
+    const filtered = dataStore.signals.filter((signal) => {
+        if (!strategyId) return true;
+        return signal.strategyId === strategyId;
+    });
+
+    res.json({
+        ok: true,
+        signals: filtered.slice().reverse()
+    });
+});
+
+adminRouter.get('/metrics', (req, res) => {
+    refreshMetricsSnapshot();
+    res.json({
+        visitors: {
+            active: dataStore.metrics.visitors.active || 0,
+            totalSessions: dataStore.metrics.visitors.totalSessions || 0,
+            lastVisitAt: dataStore.metrics.visitors.lastVisitAt
+        },
+        signalRecipients: {
+            active: dataStore.metrics.signalRecipients.active,
+            lastSignalAt: dataStore.metrics.signalRecipients.lastSignalAt,
+            lastDeliveredCount: dataStore.metrics.signalRecipients.lastDeliveredCount
+        },
+        webhook: {
+            ready: Boolean(dataStore.webhook.url),
+            issues: dataStore.webhook.url ? [] : ['웹훅 URL이 설정되지 않았습니다.'],
+            routes: dataStore.webhook.routes,
+            lastSignal: dataStore.metrics.lastSignal || null
+        },
+        googleSheets: {
+            configured: false,
+            lastStatus: 'disabled',
+            lastSyncAt: null,
+            lastError: null
+        }
+    });
+});
+
+adminRouter.get('/webhook', (req, res) => {
+    if (!dataStore.webhook.url) {
+        return res.status(404).json({ ok: false, message: 'Webhook not configured' });
+    }
+    return res.json({
+        url: dataStore.webhook.url,
+        secret: dataStore.webhook.secret,
+        createdAt: dataStore.webhook.createdAt,
+        updatedAt: dataStore.webhook.updatedAt,
+        alreadyExists: true
+    });
+});
+
+adminRouter.post('/webhook', (req, res) => {
+    if (dataStore.webhook.url) {
+        return res.json({
+            url: dataStore.webhook.url,
+            secret: dataStore.webhook.secret,
+            createdAt: dataStore.webhook.createdAt,
+            updatedAt: dataStore.webhook.updatedAt,
+            alreadyExists: true
+        });
+    }
+
+    const identifier = crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2, 12);
+    const webhookUrl = `https://hooks.example.com/tradingview/${identifier}`;
+    const webhookSecret = `whsec_${Math.random().toString(16).slice(2, 10)}`;
+    dataStore.webhook.url = webhookUrl;
+    dataStore.webhook.secret = webhookSecret;
+    dataStore.webhook.createdAt = nowIsoString();
+    dataStore.webhook.updatedAt = dataStore.webhook.createdAt;
+    dataStore.webhook.routes = serialiseStrategies()
+        .filter((strategy) => strategy.active)
+        .map((strategy) => strategy.id);
+
+    appendLog('[WEBHOOK] 새 웹훅 URL이 생성되었습니다.');
+
+    res.json({
+        url: webhookUrl,
+        secret: webhookSecret,
+        createdAt: dataStore.webhook.createdAt,
+        updatedAt: dataStore.webhook.updatedAt,
+        alreadyExists: false
+    });
+});
+
+adminRouter.put('/webhook/routes', (req, res) => {
+    const strategies = Array.isArray(req.body?.strategies) ? req.body.strategies : [];
+    dataStore.webhook.routes = strategies
+        .map((id) => normaliseString(id))
+        .filter((id) => id && dataStore.strategies.has(id));
+    dataStore.webhook.updatedAt = nowIsoString();
+
+    appendLog('[WEBHOOK] 전달 대상 전략이 업데이트되었습니다.');
+
+    res.json({ ok: true, routes: dataStore.webhook.routes });
+});
+
+adminRouter.get('/webhook/deliveries', (req, res) => {
+    res.json({
+        deliveries: dataStore.webhookDeliveries.slice().reverse()
+    });
+});
+
+adminRouter.post('/users/approve', (req, res) => {
+    const uid = normaliseString(req.body?.uid);
+    if (!uid) {
+        return res.status(400).json({ ok: false, message: 'UID가 필요합니다.' });
+    }
+
+    const user = ensureUserExists(uid);
+    user.status = 'approved';
+    user.updatedAt = nowIsoString();
+    user.approvedAt = nowIsoString();
+    if (!user.accessKey) {
+        user.accessKey = generateAccessKey();
+    }
+    if (!user.approvedStrategies.length) {
+        user.approvedStrategies = user.requestedStrategies.length
+            ? user.requestedStrategies.slice()
+            : serialiseStrategies()
+                  .filter((strategy) => strategy.active)
+                  .map((strategy) => strategy.id);
+    }
+
+    dataStore.metrics.signalRecipients.active = Array.from(dataStore.users.values()).filter((item) => item.status === 'approved').length;
+
+    appendLog(`[ADMIN] UID ${uid}가 승인되었습니다.`);
+
+    res.json({ ok: true, status: user.status, accessKey: user.accessKey });
+});
+
+adminRouter.post('/users/deny', (req, res) => {
+    const uid = normaliseString(req.body?.uid);
+    if (!uid) {
+        return res.status(400).json({ ok: false, message: 'UID가 필요합니다.' });
+    }
+
+    const user = ensureUserExists(uid);
+    user.status = 'denied';
+    user.approvedStrategies = [];
+    user.accessKey = null;
+    user.autoTradingEnabled = false;
+    user.updatedAt = nowIsoString();
+
+    appendLog(`[ADMIN] UID ${uid}가 거절되었습니다.`, 'warn');
+
+    res.json({ ok: true, status: user.status });
+});
+
+adminRouter.delete('/users/:uid', (req, res) => {
+    const uid = normaliseString(req.params.uid);
+    if (!uid || !dataStore.users.has(uid)) {
+        return res.status(404).json({ ok: false, message: '사용자를 찾을 수 없습니다.' });
+    }
+
+    dataStore.users.delete(uid);
+    appendLog(`[ADMIN] UID ${uid}가 삭제되었습니다.`, 'warn');
+    res.json({ ok: true });
+});
+
+adminRouter.post('/strategies', (req, res) => {
+    const name = normaliseString(req.body?.name);
+    if (!name) {
+        return res.status(400).json({ ok: false, message: '전략 이름이 필요합니다.' });
+    }
+
+    const idBase = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'strategy';
+    let id = idBase;
+    let counter = 1;
+    while (dataStore.strategies.has(id)) {
+        id = `${idBase}-${counter}`;
+        counter += 1;
+    }
+
+    const strategy = {
+        id,
+        name,
+        description: normaliseString(req.body?.description),
+        active: true,
+        createdAt: nowIsoString(),
+        updatedAt: nowIsoString()
+    };
+
+    dataStore.strategies.set(id, strategy);
+    appendLog(`[ADMIN] 새 전략 ${name}이(가) 추가되었습니다.`);
+    res.json({ ok: true, strategy });
+});
+
+adminRouter.patch('/strategies/:id', (req, res) => {
+    const id = normaliseString(req.params.id);
+    const strategy = id ? dataStore.strategies.get(id) : null;
+    if (!strategy) {
+        return res.status(404).json({ ok: false, message: '전략을 찾을 수 없습니다.' });
+    }
+
+    const nextActive = req.body?.active !== undefined ? Boolean(req.body.active) : !strategy.active;
+    strategy.active = nextActive;
+    strategy.updatedAt = nowIsoString();
+
+    appendLog(`[ADMIN] 전략 ${strategy.name}의 상태가 업데이트되었습니다.`);
+
+    res.json({ ok: true, strategy });
 });
 
 // 미들웨어
@@ -171,6 +823,35 @@ app.get('/', serveDashboard);
 // 관리자/프론트엔드 라우트는 모두 동일한 대시보드를 서빙
 app.get(['/admin', '/admin/*'], serveDashboard);
 
+app.get(['/api/logs', '/logs'], (req, res) => {
+    res.json({ logs: serialiseLogs() });
+});
+
+app.post(['/api/metrics/visit', '/metrics/visit'], (req, res) => {
+    const providedSessionId = normaliseString(req.body?.sessionId);
+    const sessionId = providedSessionId || (crypto.randomUUID ? crypto.randomUUID() : `session_${Math.random().toString(16).slice(2, 10)}`);
+    const pathVisited = normaliseString(req.body?.path) || '/';
+    const referrer = normaliseString(req.body?.referrer);
+
+    dataStore.metrics.sessions.set(sessionId, {
+        id: sessionId,
+        path: pathVisited,
+        referrer,
+        lastSeen: Date.now()
+    });
+
+    dataStore.metrics.totalVisits += 1;
+    dataStore.metrics.lastVisitAt = nowIsoString();
+    refreshMetricsSnapshot();
+
+    res.json({ ok: true, sessionId });
+});
+
+app.get(['/api/user/status', '/status'], handleUserStatus);
+app.post(['/api/register', '/register'], handleRegister);
+app.get(['/api/user/signals', '/signals'], handleUserSignals);
+app.get(['/api/positions', '/positions'], handlePositions);
+
 // Webhook endpoint
 app.post('/webhook', (req, res) => {
     console.log('Webhook received:', req.body);
@@ -235,6 +916,8 @@ app.post('/api/trading/auto', (req, res) => {
     const enabled = !!(req.body && req.body.enabled);
     res.json({ ok: true, autoTradingEnabled: enabled });
 });
+
+app.use('/api/admin', adminRouter);
 
 // 0.0.0.0에 바인딩하여 모든 네트워크 인터페이스에서 수신
 app.listen(PORT, '0.0.0.0', () => {


### PR DESCRIPTION
## Summary
- seed the simple Express server with demo strategies, users, signals, positions and logs so the UI can render without upstream services
- add REST handlers for user status, registration, signals, positions, metrics and visit logging (with legacy path aliases)
- expose mock administrator APIs for overview, metrics, webhook management, and user/strategy moderation backed by the in-memory store

## Testing
- npm run build *(fails: vite binary missing because dependencies cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d4bc676ea0832caa67a9931433300d